### PR TITLE
Updates to stay with compose PR

### DIFF
--- a/try_dask.py
+++ b/try_dask.py
@@ -5,17 +5,17 @@ Created on 11.07.2015
 @author: Matthew Rocklin
 '''
 
+from __future__ import division
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 import dask
 from sklearn.svm import SVC
 from sklearn import cross_validation
-from dask.compose import daskify, value
+from dask.compose import do, value
 from dask.async import get_sync
 
-D = daskify
-
+@do
 def train_test(reg_param, train_idx, test_idx, X, y):
     svm = SVC(C=reg_param)
     svm.fit(X[train_idx, :], y[train_idx])
@@ -31,21 +31,21 @@ n_folds = 4
 kf_test = cross_validation.KFold(n, n_folds=n_folds)
 score_params = list()
 test_scores = []
+
 for model_sel_idx, test_idx in kf_test:
     X_train = X[model_sel_idx]
     y_train = y[model_sel_idx]
 
     for reg_param in reg_params:
         kf = cross_validation.KFold(len(model_sel_idx), n_folds=n_folds)
-        scores = [D(train_test)(reg_param, train_idx, val_idx, X_train, y_train)
+        scores = [train_test(reg_param, train_idx, val_idx, X_train, y_train)
                   for train_idx, val_idx in kf]
-        score = D(sum)(scores) / n_folds
+        score = do(sum)(scores) / n_folds
         score_params.append([score, reg_param])
+    best_param = do(max)(score_params)[1]
 
-    best_param = D(max)(score_params)[1]
+    test_scores += [train_test(best_param, model_sel_idx, test_idx, X, y)]
 
-    test_scores += [D(train_test)(best_param, model_sel_idx, test_idx, X, y)]
-
-test_score = D(sum)(test_scores) / n_folds
+test_score = do(sum)(test_scores) / n_folds
 
 print test_score.compute()


### PR DESCRIPTION
Updated to run with current dask PR https://github.com/ContinuumIO/dask/pull/408.

Running, and then calling `visualize` on `test_score` produces the following graph:

![mydask](https://cloud.githubusercontent.com/assets/2783717/8662589/0ddc9430-2987-11e5-886f-529fcf8cec47.png)
